### PR TITLE
Fix paths and typo in configuration for Void Linux

### DIFF
--- a/.config/sway/config
+++ b/.config/sway/config
@@ -22,7 +22,7 @@ set $down j
 set $up k
 set $right l
 set $term footclient
-set $lock ~/.config/sway/scripts/screenlocker
+set $lock ~/.config/sway/scripts/screenlocker.sh
 set $killer ~/.local/bin/bemenu_killer
 
 set $drun j4-dmenu-desktop --dmenu="bemenu_runner -B1 -n -l10 -p drun:"
@@ -349,7 +349,7 @@ client.background       $fg
 # Auto start
 exec foot --server
 exec_always ~/.config/waybar/scripts/waybar-launcher.sh
-exec /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
+exec /usr/libexec/polkit-gnome-authentication-agent-1
 exec wl-paste --watch cliphist -max-items 100 store
 exec mako
 exec dbus-update-activation-environment DISPLAY I3SOCK SWAYSOCK WAYLAND_DISPLAY

--- a/.config/sway/scripts/swayidle-toggle.sh
+++ b/.config/sway/scripts/swayidle-toggle.sh
@@ -7,6 +7,7 @@ else
   notify-send -a center_notify "Swayidle" "Enabled" -t 1500 -h string:x-canonical-private-synchronous:volume
   swayidle -w \
     timeout 1800 'swaylock -f -C ~/.config/swaylock/config' \
-    timeout 3600 'swaymsg "output * power off"' resume 'swaymsg "output * power on"' \
+    timeout 3600 'swaymsg "output * power off"' \
+    resume 'swaymsg "output * power on"' \
     before-sleep 'swaylock -f -C ~/.config/swaylock/config' &
 fi

--- a/.config/waybar/scripts/swayidle.sh
+++ b/.config/waybar/scripts/swayidle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if pgrep -x "swayidle" > /dev/null; then
-    echo ""
+if pgrep -x "swayidle" >/dev/null; then
+  echo ""
 else
-    echo "{\"text\": \"󰒳\", \"tooltip\": \"<b>Swayidle</b> is disabled\"}"
+  echo "{\"text\": \"󰒳\", \"tooltip\": \"<b>Swayidle</b> is disabled\"}"
 fi

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -26,6 +26,7 @@ tooltip {
     background: @bg;
     border: solid 1px @bg3;
 }
+
 tooltip label {
     color: @fg;
 }
@@ -80,7 +81,7 @@ window#waybar.hidden {
  * ----------------------------------------------------- */
 
 #cpu,
-#memory ,
+#memory,
 #battery,
 #pulseaudio,
 #wireplumber,

--- a/.local/bin/bemenu_emoji
+++ b/.local/bin/bemenu_emoji
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-chosen=$(cut -d ';' -f1 ~/.local/share/emoji/emoji | bemenu_runner -l 15 -n -p "select emoji:"| sed "s/ .*//")
+chosen=$(cut -d ';' -f1 ~/.local/share/emoji/emoji | bemenu_runner -l 15 -n -p "select emoji:" | sed "s/ .*//")
 
 [ -z "$chosen" ] && exit
 
 if [ -n "$1" ]; then
-	wl-copy "$chosen"
+  wl-copy "$chosen"
 else
-		printf "$chosen" | wl-copy
-		notify-send "$chosen Copied to clipboard!" &
+  printf "$chosen" | wl-copy
+  notify-send "$chosen Copied to clipboard!" &
 fi

--- a/.zprofile
+++ b/.zprofile
@@ -19,11 +19,8 @@ export INPUTRC="$XDG_CONFIG_HOME/shell/inputrc"
 export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 export HISTFILE="$XDG_DATA_HOME/history"
 export SSH_AUTH_SOCK="$XDG_CACHE_HOME/ssh-agent.sock"
-export DOTBARE_BACKUP="${XDG_DATA_HOME:-$HOME/.local/share}/dotbare"
-export DOTBARE_DIR="$HOME/Documents/.dots/"
-export DOTBARE_TREE="$HOME"
 
-# Start River environment
+# Start Sway environment
 if [ -z "$WAYLAND_DISPLAY" ] && [ "$XDG_VTNR" -eq 1 ]; then
   exec $HOME/.local/bin/sway-start
 fi


### PR DESCRIPTION
- Updated the exec path for polkit-gnome-authentication-agent-1 from /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 to /usr/libexec/polkit-gnome-authentication-agent-1 to ensure compatibility with Void Linux.
- Corrected the set  line in the configuration from ~/.config/sway/scripts/screenlocker to ~/.config/sway/scripts/screenlocker.sh to address a typo.
- Cleaned up the .zprofile file from dotbare.